### PR TITLE
Feat: #32 Perenual API 자동 호출 기능 구현

### DIFF
--- a/backend/plantory_be/.gitignore
+++ b/backend/plantory_be/.gitignore
@@ -39,3 +39,6 @@ out/
 .vscode/
 .DS_Store
 src/main/resources/application.yml
+node_modules/
+package-lock.json
+package.json

--- a/backend/plantory_be/src/main/java/org/example/plantory_be/controller/PlantDictionaryController.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/controller/PlantDictionaryController.java
@@ -2,9 +2,7 @@ package org.example.plantory_be.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.example.plantory_be.dto.response.PlantDictionaryResponse;
 import org.example.plantory_be.entity.PlantDictionary;
-import org.example.plantory_be.repository.PlantDictionaryRepository;
 import org.example.plantory_be.service.PlantDictionaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,16 +18,22 @@ public class PlantDictionaryController {
 
     private final PlantDictionaryService plantDictionaryService;
 
-
+    /**
+     * 전체 식물 조회
+     * DB가 비어 있으면 Perenual API 자동 호출 → 저장 후 반환
+     */
     @GetMapping
     public List<PlantDictionary> getAllPlants() {
-        return plantDictionaryService.getAllPlants();
+        return plantDictionaryService.getOrFetchAllPlants();
     }
 
-
+    /**
+     * Perenual ID 기준으로 특정 식물 조회
+     * DB에 없으면 Perenual API 자동 호출 → 저장 후 반환
+     */
     @GetMapping("/perenual/{perenualId}")
     public ResponseEntity<PlantDictionary> getPlantByPerenualId(@PathVariable Long perenualId) {
-        PlantDictionary plant = plantDictionaryService.getPlantByPerenualId(perenualId);
+        PlantDictionary plant = plantDictionaryService.getOrFetchPlantByPerenualId(perenualId);
         if (plant != null) {
             return ResponseEntity.ok(plant);
         } else {
@@ -37,13 +41,10 @@ public class PlantDictionaryController {
         }
     }
 
-    @GetMapping("/plants/save")
-    public String savePlantsFromApi() {
-        plantDictionaryService.fetchAndSavePlants();
-        return " Perenual 데이터 저장 완료!";
-    }
-
-    // Perenual API 데이터 가져와 DB에 저장 (테스트용)
+    /**
+     * Perenual API 데이터 수동 저장 (테스트용)
+     * 호출 시 강제로 1페이지 데이터 저장
+     */
     @GetMapping("/fetch")
     public String fetchAndSavePlants() {
         plantDictionaryService.fetchAndSavePlants();
@@ -51,8 +52,9 @@ public class PlantDictionaryController {
     }
 
     @GetMapping("/search")
-    public List<PlantDictionaryResponse> searchPlants(@RequestParam(required = false) String query) {
-        return plantDictionaryService.searchPlants(query);
+    public ResponseEntity<List<PlantDictionary>> searchPlants(@RequestParam String query) {
+        List<PlantDictionary> results = plantDictionaryService.searchPlants(query);
+        return ResponseEntity.ok(results);
     }
 
 }

--- a/backend/plantory_be/src/main/java/org/example/plantory_be/repository/PlantDictionaryRepository.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/repository/PlantDictionaryRepository.java
@@ -13,15 +13,19 @@ public interface PlantDictionaryRepository extends JpaRepository<PlantDictionary
 
     Optional<PlantDictionary> findByPerenualId(Long perenualId);
 
+    // 검색 대상: commonName(영문 일반명), englishName(영어명), scientificName(학명), koreanName(한글명), origin(원산지), familyName(과 이름)
     @Query("""
-        SELECT p FROM PlantDictionary p
-        WHERE (:query IS NULL OR TRIM(:query) = '' 
-               OR LOWER(CAST(p.commonName AS string)) LIKE LOWER(CONCAT('%', TRIM(:query), '%'))
-               OR LOWER(CAST(p.koreanName AS string)) LIKE LOWER(CONCAT('%', TRIM(:query), '%'))
-               OR LOWER(CAST(p.englishName AS string)) LIKE LOWER(CONCAT('%', TRIM(:query), '%'))
-               OR LOWER(CAST(p.scientificName AS string)) LIKE LOWER(CONCAT('%', TRIM(:query), '%'))
-               OR LOWER(CAST(p.origin AS string)) LIKE LOWER(CONCAT('%', TRIM(:query), '%'))
-               OR LOWER(CAST(p.familyName AS string)) LIKE LOWER(CONCAT('%', TRIM(:query), '%')))
-        """)
+    SELECT p FROM PlantDictionary p
+    WHERE (:query IS NULL OR TRIM(:query) = ''
+           OR REPLACE(LOWER(p.commonName), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
+           OR REPLACE(LOWER(p.koreanName), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
+           OR REPLACE(LOWER(p.englishName), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
+           OR REPLACE(LOWER(p.scientificName), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
+           OR REPLACE(LOWER(p.origin), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
+           OR REPLACE(LOWER(p.familyName), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
+    )
+""")
     List<PlantDictionary> searchPlants(@Param("query") String query);
+
+
 }

--- a/backend/plantory_be/src/main/java/org/example/plantory_be/service/PerenualApiService.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/service/PerenualApiService.java
@@ -1,0 +1,25 @@
+package org.example.plantory_be.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class PerenualApiService {
+
+    @Value("${perenual.api.key}")
+    private String apiKey;
+
+    private static final String BASE_URL = "https://perenual.com/api/species/details/";
+
+    // 식물 ID 기반으로 상세 데이터 호출
+    public String fetchPlantData(Long plantId) {
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL + plantId)
+            .queryParam("key", apiKey)
+            .toUriString();
+
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.getForObject(url, String.class);
+    }
+}

--- a/backend/plantory_be/src/main/java/org/example/plantory_be/service/PlantDictionaryService.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/service/PlantDictionaryService.java
@@ -2,9 +2,8 @@ package org.example.plantory_be.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.example.plantory_be.dto.response.PlantDictionaryResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.example.plantory_be.entity.PlantDictionary;
 import org.example.plantory_be.repository.PlantDictionaryRepository;
 import org.json.JSONArray;
@@ -13,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlantDictionaryService {
@@ -25,76 +25,138 @@ public class PlantDictionaryService {
     @Value("${perenual.api.base-url}")
     private String baseUrl;
 
-
     public List<PlantDictionary> getAllPlants() {
         return plantDictionaryRepository.findAll();
     }
-
 
     public PlantDictionary getPlantByPerenualId(Long perenualId) {
         return plantDictionaryRepository.findByPerenualId(perenualId).orElse(null);
     }
 
-    // Perenual API 데이터 가져와 DB에 저장
-    public void fetchAndSavePlants() {
+    public List<PlantDictionary> getOrFetchAllPlants() {
+        List<PlantDictionary> plants = plantDictionaryRepository.findAll();
+
+        if (plants.isEmpty()) {
+            log.info("[자동 호출] DB 비어있음 → Perenual species-list 호출 시작 (page=1)");
+            long t0 = System.nanoTime();
+            fetchAndSavePlants();
+            long ms = (System.nanoTime() - t0) / 1_000_000;
+            plants = plantDictionaryRepository.findAll();
+            log.info("[자동 호출 완료] {}개 저장 ({} ms)", plants.size(), ms);
+        } else {
+            log.debug("[캐시 히트] DB에서 {}개 반환", plants.size());
+        }
+
+        return plants;
+    }
+
+    public PlantDictionary getOrFetchPlantByPerenualId(Long perenualId) {
+        return plantDictionaryRepository.findByPerenualId(perenualId)
+            .orElseGet(() -> {
+                log.info("[자동 호출] perenualId={} 미존재 → details 호출 시작", perenualId);
+                long t0 = System.nanoTime();
+
+                PlantDictionary fetchedPlant = fetchSinglePlant(perenualId);
+                if (fetchedPlant != null) {
+                    plantDictionaryRepository.save(fetchedPlant);
+                    long ms = (System.nanoTime() - t0) / 1_000_000;
+                    log.info("[자동 저장 완료] perenualId={} ({} ms)", perenualId, ms);
+                } else {
+                    log.warn("[자동 호출 실패] perenualId={} : Perenual 응답 없음/파싱 실패", perenualId);
+                }
+                return fetchedPlant;
+            });
+    }
+
+    private PlantDictionary fetchSinglePlant(Long perenualId) {
         RestTemplate restTemplate = new RestTemplate();
-        String url = baseUrl + "/species-list?key=" + apiKey + "&page=1"; // 1페이지만 테스트용
+        String url = baseUrl + "/species/details/" + perenualId + "?key=" + apiKey;
 
-        String response = restTemplate.getForObject(url, String.class);
-        JSONObject json = new JSONObject(response);
-        JSONArray dataArray = json.getJSONArray("data");
-
-        List<PlantDictionary> plants = new ArrayList<>();
-
-        for (int i = 0; i < dataArray.length(); i++) {
-            JSONObject plantJson = dataArray.getJSONObject(i);
-            Long perenualId = Long.valueOf(plantJson.getInt("id"));
-
-            // DB 중복 방지
-            if (plantDictionaryRepository.findByPerenualId(perenualId).isPresent()) {
-                continue;
-            }
+        try {
+            log.debug("[HTTP] GET {}", url);
+            String response = restTemplate.getForObject(url, String.class);
+            JSONObject json = new JSONObject(response);
 
             PlantDictionary plant = new PlantDictionary();
             plant.setPerenualId(perenualId);
-            plant.setCommonName(plantJson.optString("common_name", "Unknown"));
+            plant.setCommonName(json.optString("common_name", "Unknown"));
 
+            if (json.has("scientific_name") && json.get("scientific_name") instanceof JSONArray) {
+                plant.setScientificName(json.getJSONArray("scientific_name").optString(0, ""));
+            } else {
+                plant.setScientificName(json.optString("scientific_name", ""));
+            }
 
-            plant.setScientificName(
-                plantJson.has("scientific_name") && plantJson.get("scientific_name") instanceof JSONArray
-                    ? plantJson.getJSONArray("scientific_name").optString(0, "")
-                    : plantJson.optString("scientific_name", "")
-            );
+            if (json.has("other_name") && json.get("other_name") instanceof JSONArray) {
+                JSONArray otherNames = json.getJSONArray("other_name");
+                plant.setOtherName(otherNames.length() > 0 ? otherNames.optString(0, "") : "");
+            }
 
-
-            plant.setOtherName(
-                plantJson.has("other_name") && plantJson.get("other_name") instanceof JSONArray &&
-                    plantJson.getJSONArray("other_name").length() > 0
-                    ? plantJson.getJSONArray("other_name").optString(0, "")
-                    : ""
-            );
-
-
-            if (plantJson.has("default_image") && !plantJson.isNull("default_image")) {
-                JSONObject imageObj = plantJson.getJSONObject("default_image");
+            if (json.has("default_image") && !json.isNull("default_image")) {
+                JSONObject imageObj = json.getJSONObject("default_image");
                 plant.setImageUrl(imageObj.optString("regular_url", ""));
             }
 
-            plants.add(plant);
+            return plant;
+        } catch (Exception e) {
+            log.error("단일 식물 API 호출/파싱 실패 perenualId={}: {}", perenualId, e.getMessage(), e);
+            return null;
         }
-
-        plantDictionaryRepository.saveAll(plants);
-        System.out.println(plants.size() + "개 식물 저장 완료!");
     }
 
-    public List<PlantDictionaryResponse> searchPlants(String query) {
-        if (query == null || query.isBlank() || "null".equalsIgnoreCase(query.trim())) query = null;
+    public void fetchAndSavePlants() {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = baseUrl + "/species-list?key=" + apiKey + "&page=1";
 
-        List<PlantDictionary> plants = plantDictionaryRepository.searchPlants(query);
+        try {
+            log.debug("[HTTP] GET {}", url);
+            String response = restTemplate.getForObject(url, String.class);
+            JSONObject json = new JSONObject(response);
+            JSONArray dataArray = json.getJSONArray("data");
 
-        return plants.stream()
-            .map(PlantDictionaryResponse::fromEntity)
-            .collect(Collectors.toList());
+            List<PlantDictionary> plants = new ArrayList<>();
+
+            for (int i = 0; i < dataArray.length(); i++) {
+                JSONObject plantJson = dataArray.getJSONObject(i);
+                Long perenualId = Long.valueOf(plantJson.getInt("id"));
+
+                if (plantDictionaryRepository.findByPerenualId(perenualId).isPresent()) {
+                    log.trace("중복 스킵 perenualId={}", perenualId);
+                    continue;
+                }
+
+                PlantDictionary plant = new PlantDictionary();
+                plant.setPerenualId(perenualId);
+                plant.setCommonName(plantJson.optString("common_name", "Unknown"));
+
+                if (plantJson.has("scientific_name") && plantJson.get("scientific_name") instanceof JSONArray) {
+                    plant.setScientificName(plantJson.getJSONArray("scientific_name").optString(0, ""));
+                } else {
+                    plant.setScientificName(plantJson.optString("scientific_name", ""));
+                }
+
+                if (plantJson.has("other_name") && plantJson.get("other_name") instanceof JSONArray &&
+                    plantJson.getJSONArray("other_name").length() > 0) {
+                    plant.setOtherName(plantJson.getJSONArray("other_name").optString(0, ""));
+                }
+
+                if (plantJson.has("default_image") && !plantJson.isNull("default_image")) {
+                    JSONObject imageObj = plantJson.getJSONObject("default_image");
+                    plant.setImageUrl(imageObj.optString("regular_url", ""));
+                }
+
+                plants.add(plant);
+            }
+
+            plantDictionaryRepository.saveAll(plants);
+            log.info("{}개 식물 저장 완료 (species-list page=1)", plants.size());
+        } catch (Exception e) {
+            log.error("식물 리스트 API 호출 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    public List<PlantDictionary> searchPlants(String query) {
+        return plantDictionaryRepository.searchPlants(query);
     }
 
 }


### PR DESCRIPTION
## Summary
Perenual API를 수동으로 호출해야 했던 과정을 자동화하여,
DB가 비어 있을 경우 API가 자동으로 호출되고 데이터를 저장하도록 구현했습니다.
- closed #32 

## Key Changes
- PerenualApiService 신규 생성 (외부 API 호출 전용)
- PlantDictionaryService에 자동 호출 로직 추가
- Repository, Controller 일부 수정
- .gitignore에 node_modules 등 추가

## Testing 
자동 호출 기능 테스트 완료.
<img width="1840" height="867" alt="스크린샷 2025-10-23 오후 11 04 05" src="https://github.com/user-attachments/assets/01befe68-ca19-4836-8f08-6525369dd456" />
<img width="1761" height="777" alt="스크린샷 2025-10-23 오후 11 05 16" src="https://github.com/user-attachments/assets/cb13b438-1479-44a7-bb4d-71eb96e8afb3" />

자동 호출 기능을 테스트하시려면 `plant_dictionary` 테이블을 수동으로 비운 뒤,  
서버를 실행하고 plantory 사이트의 “식물 검색” 탭에 접속해 보시면 됩니다. 
페이지 진입 시 자동으로 Perenual API가 호출되어 데이터가 저장됩니다.

## To Reviewers
application.yml 설정 다시 정리해두겠습니다. 확인 부탁드립니다! 