### PR TITLE
Feat: 식물 백과사전 데이터 확장 및 페이지네이션 적용

### DIFF
--- a/backend/plantory_be/src/main/java/org/example/plantory_be/controller/PlantDictionaryController.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/controller/PlantDictionaryController.java
@@ -1,15 +1,11 @@
 package org.example.plantory_be.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.plantory_be.entity.PlantDictionary;
 import org.example.plantory_be.service.PlantDictionaryService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/plants")
@@ -19,42 +15,33 @@ public class PlantDictionaryController {
     private final PlantDictionaryService plantDictionaryService;
 
     /**
-     * 전체 식물 조회
-     * DB가 비어 있으면 Perenual API 자동 호출 → 저장 후 반환
+     * 페이지 기반 목록 조회 및 검색(자동 호출 포함)
      */
-    @GetMapping
-    public List<PlantDictionary> getAllPlants() {
-        return plantDictionaryService.getOrFetchAllPlants();
+    @GetMapping("/page")
+    public ResponseEntity<Page<PlantDictionary>> getPlantsPage(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size,
+        @RequestParam(required = false) String query
+    ) {
+        Page<PlantDictionary> result = plantDictionaryService.getPlantsPage(page, size, query);
+        return ResponseEntity.ok(result);
     }
 
     /**
-     * Perenual ID 기준으로 특정 식물 조회
-     * DB에 없으면 Perenual API 자동 호출 → 저장 후 반환
+     * 개별 식물 조회
      */
     @GetMapping("/perenual/{perenualId}")
     public ResponseEntity<PlantDictionary> getPlantByPerenualId(@PathVariable Long perenualId) {
         PlantDictionary plant = plantDictionaryService.getOrFetchPlantByPerenualId(perenualId);
-        if (plant != null) {
-            return ResponseEntity.ok(plant);
-        } else {
-            return ResponseEntity.notFound().build();
-        }
+        return plant != null ? ResponseEntity.ok(plant) : ResponseEntity.notFound().build();
     }
 
     /**
-     * Perenual API 데이터 수동 저장 (테스트용)
-     * 호출 시 강제로 1페이지 데이터 저장
+     * 테스트용 강제 데이터 로드
      */
     @GetMapping("/fetch")
     public String fetchAndSavePlants() {
-        plantDictionaryService.fetchAndSavePlants();
+        plantDictionaryService.fetchAndSavePlants(10);
         return "식물 데이터 저장 완료!";
     }
-
-    @GetMapping("/search")
-    public ResponseEntity<List<PlantDictionary>> searchPlants(@RequestParam String query) {
-        List<PlantDictionary> results = plantDictionaryService.searchPlants(query);
-        return ResponseEntity.ok(results);
-    }
-
 }

--- a/backend/plantory_be/src/main/java/org/example/plantory_be/repository/PlantDictionaryRepository.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/repository/PlantDictionaryRepository.java
@@ -3,6 +3,8 @@ package org.example.plantory_be.repository;
 import java.util.List;
 import java.util.Optional;
 import org.example.plantory_be.entity.PlantDictionary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,7 +15,6 @@ public interface PlantDictionaryRepository extends JpaRepository<PlantDictionary
 
     Optional<PlantDictionary> findByPerenualId(Long perenualId);
 
-    // 검색 대상: commonName(영문 일반명), englishName(영어명), scientificName(학명), koreanName(한글명), origin(원산지), familyName(과 이름)
     @Query("""
     SELECT p FROM PlantDictionary p
     WHERE (:query IS NULL OR TRIM(:query) = ''
@@ -25,7 +26,7 @@ public interface PlantDictionaryRepository extends JpaRepository<PlantDictionary
            OR REPLACE(LOWER(p.familyName), ' ', '') LIKE LOWER(CONCAT('%', REPLACE(TRIM(:query), ' ', ''), '%'))
     )
 """)
-    List<PlantDictionary> searchPlants(@Param("query") String query);
+    Page<PlantDictionary> searchPlants(@Param("query") String query, Pageable pageable);
 
-
+    Page<PlantDictionary> findAll(Pageable pageable);
 }

--- a/backend/plantory_be/src/main/java/org/example/plantory_be/service/PlantDictionaryService.java
+++ b/backend/plantory_be/src/main/java/org/example/plantory_be/service/PlantDictionaryService.java
@@ -9,6 +9,9 @@ import org.example.plantory_be.repository.PlantDictionaryRepository;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -26,7 +29,7 @@ public class PlantDictionaryService {
     private String baseUrl;
 
     public List<PlantDictionary> getAllPlants() {
-        return plantDictionaryRepository.findAll();
+        return getOrFetchAllPlants();
     }
 
     public PlantDictionary getPlantByPerenualId(Long perenualId) {
@@ -39,7 +42,7 @@ public class PlantDictionaryService {
         if (plants.isEmpty()) {
             log.info("[자동 호출] DB 비어있음 → Perenual species-list 호출 시작 (page=1)");
             long t0 = System.nanoTime();
-            fetchAndSavePlants();
+            fetchAndSavePlants(5);
             long ms = (System.nanoTime() - t0) / 1_000_000;
             plants = plantDictionaryRepository.findAll();
             log.info("[자동 호출 완료] {}개 저장 ({} ms)", plants.size(), ms);
@@ -104,59 +107,66 @@ public class PlantDictionaryService {
         }
     }
 
-    public void fetchAndSavePlants() {
+    public void fetchAndSavePlants(int maxPages) {
         RestTemplate restTemplate = new RestTemplate();
-        String url = baseUrl + "/species-list?key=" + apiKey + "&page=1";
 
-        try {
-            log.debug("[HTTP] GET {}", url);
-            String response = restTemplate.getForObject(url, String.class);
-            JSONObject json = new JSONObject(response);
-            JSONArray dataArray = json.getJSONArray("data");
+        int startPage = 5;
 
-            List<PlantDictionary> plants = new ArrayList<>();
+        for (int page = startPage; page < startPage + maxPages; page++) {
+            String url = baseUrl + "/species-list?key=" + apiKey + "&page=" + page;
+            log.info("[HTTP] GET {}", url);
 
-            for (int i = 0; i < dataArray.length(); i++) {
-                JSONObject plantJson = dataArray.getJSONObject(i);
-                Long perenualId = Long.valueOf(plantJson.getInt("id"));
+            try {
+                String response = restTemplate.getForObject(url, String.class);
+                JSONObject json = new JSONObject(response);
+                JSONArray dataArray = json.getJSONArray("data");
 
-                if (plantDictionaryRepository.findByPerenualId(perenualId).isPresent()) {
-                    log.trace("중복 스킵 perenualId={}", perenualId);
-                    continue;
+                if (dataArray.isEmpty()) {
+                    log.info("더 이상 데이터 없음. page={}에서 중단", page);
+                    break;
                 }
 
-                PlantDictionary plant = new PlantDictionary();
-                plant.setPerenualId(perenualId);
-                plant.setCommonName(plantJson.optString("common_name", "Unknown"));
+                List<PlantDictionary> newPlants = new ArrayList<>();
 
-                if (plantJson.has("scientific_name") && plantJson.get("scientific_name") instanceof JSONArray) {
-                    plant.setScientificName(plantJson.getJSONArray("scientific_name").optString(0, ""));
-                } else {
-                    plant.setScientificName(plantJson.optString("scientific_name", ""));
+                for (int i = 0; i < dataArray.length(); i++) {
+                    JSONObject plantJson = dataArray.getJSONObject(i);
+                    Long perenualId = (long) plantJson.getInt("id");
+
+                    if (plantDictionaryRepository.findByPerenualId(perenualId).isPresent()) {
+                        continue;
+                    }
+
+                    PlantDictionary plant = new PlantDictionary();
+                    plant.setPerenualId(perenualId);
+                    plant.setCommonName(plantJson.optString("common_name", "Unknown"));
+
+                    if (plantJson.has("default_image") && !plantJson.isNull("default_image")) {
+                        JSONObject imageObj = plantJson.getJSONObject("default_image");
+                        plant.setImageUrl(imageObj.optString("regular_url", ""));
+                    }
+
+                    newPlants.add(plant);
                 }
 
-                if (plantJson.has("other_name") && plantJson.get("other_name") instanceof JSONArray &&
-                    plantJson.getJSONArray("other_name").length() > 0) {
-                    plant.setOtherName(plantJson.getJSONArray("other_name").optString(0, ""));
-                }
+                plantDictionaryRepository.saveAll(newPlants);
+                log.info("[page {}] {}개 저장 완료", page, newPlants.size());
 
-                if (plantJson.has("default_image") && !plantJson.isNull("default_image")) {
-                    JSONObject imageObj = plantJson.getJSONObject("default_image");
-                    plant.setImageUrl(imageObj.optString("regular_url", ""));
-                }
-
-                plants.add(plant);
+            } catch (Exception e) {
+                log.error("API 호출 실패 page={}: {}", page, e.getMessage());
+                break;
             }
-
-            plantDictionaryRepository.saveAll(plants);
-            log.info("{}개 식물 저장 완료 (species-list page=1)", plants.size());
-        } catch (Exception e) {
-            log.error("식물 리스트 API 호출 실패: {}", e.getMessage(), e);
         }
     }
 
-    public List<PlantDictionary> searchPlants(String query) {
-        return plantDictionaryRepository.searchPlants(query);
+
+    public Page<PlantDictionary> getPlantsPage(int page, int size, String query) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        if (query == null || query.trim().isEmpty()) {
+            return plantDictionaryRepository.findAll(pageable);
+        } else {
+            return plantDictionaryRepository.searchPlants(query, pageable);
+        }
     }
 
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { getAllPlants } from "../services/plant";
+import { getPlantsByPage } from "../services/plant";
 import {
   getNotifications,
   markAsRead,

--- a/frontend/src/pages/PlantDictionaryList.jsx
+++ b/frontend/src/pages/PlantDictionaryList.jsx
@@ -1,57 +1,61 @@
 import React, { useEffect, useState } from "react";
-import { getAllPlants, searchPlants } from "../services/plant";
-import PlantDictionaryCard from "../components/plant/PlantDictionaryCard";
 import { useNavigate, useLocation } from "react-router-dom";
+import PlantDictionaryCard from "../components/plant/PlantDictionaryCard";
+import { getPlantsByPage } from "../services/plant";
 
 const PlantDictionaryList = () => {
-  const [plants, setPlants] = useState([]);
-  const [query, setQuery] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [isSearching, setIsSearching] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
+  const [plants, setPlants] = useState([]);
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(0);
+  const [size] = useState(20);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(true);
+
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const savedQuery = params.get("query") || "";
-    setQuery(savedQuery);
+    const pageParam = parseInt(params.get("page")) || 0;
+    const queryParam = params.get("query") || "";
+
+    setPage(pageParam);
+    setQuery(queryParam);
 
     const fetchData = async () => {
       try {
         setLoading(true);
-        const data = savedQuery
-          ? await searchPlants({ query: savedQuery })
-          : await getAllPlants();
+        const res = await getPlantsByPage(pageParam, size, queryParam);
 
-        console.log("불러온 식물 데이터:", data);
-        setPlants(data);
-        setIsSearching(!!savedQuery);
-      } catch (error) {
-        console.error("식물 데이터 불러오기 실패:", error);
+        setPlants(res.data.content);
+        setTotalPages(res.data.totalPages);
+      } catch (err) {
+        console.error("식물 데이터 불러오기 실패:", err);
       } finally {
         setLoading(false);
       }
     };
 
-  
-    if (location.pathname.includes("/dictionary")) {
-      fetchData();
-    }
-  }, [location.search, location.pathname]);
+    fetchData();
+  }, [location.search]);
 
-  
-  const handleSearch = async (e) => {
+  const handleSearch = (e) => {
     e.preventDefault();
     if (!query.trim()) {
-      navigate("/dictionary/list");
+      navigate(`/dictionary/list?page=0`);
     } else {
-      navigate(`/dictionary/list?query=${encodeURIComponent(query)}`);
+      navigate(
+        `/dictionary/list?page=0&query=${encodeURIComponent(query.trim())}`
+      );
     }
   };
 
-  const handleShowAll = () => {
-    setQuery("");
-    navigate("/dictionary/list");
+  const handlePageChange = (newPage) => {
+    navigate(
+      `/dictionary/list?page=${newPage}${
+        query ? `&query=${encodeURIComponent(query)}` : ""
+      }`
+    );
   };
 
   if (loading) return <p className="p-6 text-gray-600">로딩 중...</p>;
@@ -82,12 +86,10 @@ const PlantDictionaryList = () => {
         </button>
       </form>
 
-      {/* 🌱 식물 목록 */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+      {/* 🌱 식물 카드 그리드 */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-6 pb-10">
         {plants.length > 0 ? (
-          plants.map((plant) => (
-            <PlantDictionaryCard key={plant.id} plant={plant} />
-          ))
+          plants.map((p) => <PlantDictionaryCard key={p.id} plant={p} />)
         ) : (
           <div className="col-span-full text-center mt-10 text-gray-600">
             <p className="text-lg mb-2">검색 결과가 없습니다.</p>
@@ -95,15 +97,22 @@ const PlantDictionaryList = () => {
         )}
       </div>
 
-      {/* 🌿 전체보기 버튼 (검색 중일 때만 표시) */}
-      {isSearching && (
-        <div className="text-center mt-10">
-          <button
-            onClick={handleShowAll}
-            className="inline-block bg-green-100 hover:bg-green-200 text-green-700 font-medium px-5 py-2.5 rounded-full transition-all duration-200"
-          >
-            🌿 전체 목록으로 돌아가기
-          </button>
+      {/* 📄 페이지네이션 버튼 */}
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-6">
+          {[...Array(totalPages)].map((_, idx) => (
+            <button
+              key={idx}
+              onClick={() => handlePageChange(idx)}
+              className={`px-4 py-2 rounded-lg ${
+                idx === page
+                  ? "bg-green-700 text-white"
+                  : "bg-gray-200 text-gray-700"
+              }`}
+            >
+              {idx + 1}
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/pages/userPlantDetail.jsx
+++ b/frontend/src/pages/userPlantDetail.jsx
@@ -112,7 +112,7 @@ const PlantDetail = () => {
         </div>
 
         {/* 이미지 */}
-        <div className="w-full h-64 bg-gray-100 rounded-xl overflow-hidden">
+        <div className="w-full h-auto bg-gray-100 rounded-xl overflow-hidden">
           <img
             src={
               plant.imageUrl

--- a/frontend/src/services/plant.js
+++ b/frontend/src/services/plant.js
@@ -1,43 +1,10 @@
 import axios from "axios";
 
-const API_BASE_URL = "http://localhost:8080/api";
+const API_BASE_URL = import.meta.env.VITE_API_URL + "/api";
 
-export const getAllPlants = async () => {
-  try {
-    const response = await axios.get(`${API_BASE_URL}/plants`);
-    console.log("🌿 받아온 식물 데이터:", response.data);
-    return response.data;
-  } catch (error) {
-    console.error("식물 목록 조회 실패:", error);
-    throw error;
-  }
-};
-
-
-export const getPlantById = async (id) => {
-  try {
-    const response = await axios.get(`${API_BASE_URL}/plants/${id}`);
-    console.log(`🌱 ${id}번 식물 데이터:`, response.data);
-    return response.data;
-  } catch (error) {
-    console.error(`식물 상세 조회 실패 (ID: ${id})`, error);
-    throw error;
-  }
-};
-
-
-export const searchPlants = async ({ query }) => {
-  try {
-  
-    const url = query
-      ? `${API_BASE_URL}/plants/search?query=${encodeURIComponent(query)}`
-      : `${API_BASE_URL}/plants/search`;
-
-    const response = await axios.get(url);
-    console.log("🔍 검색 결과:", response.data);
-    return response.data;
-  } catch (error) {
-    console.error("식물 검색 실패:", error);
-    throw error;
-  }
+export const getPlantsByPage = (page = 0, size = 20, query = "") => {
+  const url = `${API_BASE_URL}/plants/page?page=${page}&size=${size}&query=${encodeURIComponent(
+    query
+  )}`;
+  return axios.get(url);
 };


### PR DESCRIPTION
## Summary
식물 데이터 개수를 확장하고 백과사전 목록에 페이지네이션을 적용했습니다.
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #57 

## Key Changes
- Backend: Perenual API 다중 페이지 저장 로직 구현
- Backend: /plants/page 페이지네이션 API 추가
- Frontend: 페이지 로드 구조 개선 및 페칭 안정화
- Sidebar 식물 랜덤 추천 데이터 확장

## Testing
- 전체 목록 조회 정상 동작 확인
- 검색 및 상세 페이지 연속 탐색 정상 동작

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
